### PR TITLE
add health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /opt/zookeeper
 
 EXPOSE 2181 2888 3888
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+HEALTHCHECK --interval=5s --timeout=5s --retries=3 \
   CMD echo stat | nc localhost 2181
 
 CMD ["bin/zkServer.sh", "start-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ WORKDIR /opt/zookeeper
 
 EXPOSE 2181 2888 3888
 
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+  CMD echo stat | nc localhost 2181
+
 CMD ["bin/zkServer.sh", "start-foreground"]


### PR DESCRIPTION
Add a health check for the container for use with docker >= 1.12
This allows other containers which are depending on this container to start only if this container is started completely.